### PR TITLE
syntax error near unexpected token `&' in /CHAP_modules/CHAP_deffxn.sh and /CHAP_modules/CHAP_ana.sh

### DIFF
--- a/CHAP_modules/CHAP_ana.sh
+++ b/CHAP_modules/CHAP_ana.sh
@@ -210,7 +210,7 @@ fi
 if [[ ! -f "trajectDetails.log" ]]; then
 	echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 	sleep 2
-	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc | tee trajectDetails.log
+	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc |2>&1 | tee trajectDetails.log
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}')
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')
 	simDuratnpsINT=$(echo ${simDuratnps%\.*})
@@ -227,7 +227,7 @@ else
 	{
 		echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 		sleep 2
-		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc | tee trajectDetails.log		
+		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc |2>&1 | tee trajectDetails.log		
 	}
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}') || ScanTraj_again_if_err
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')

--- a/CHAP_modules/CHAP_ana.sh
+++ b/CHAP_modules/CHAP_ana.sh
@@ -210,7 +210,7 @@ fi
 if [[ ! -f "trajectDetails.log" ]]; then
 	echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 	sleep 2
-	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc |2>&1 | tee trajectDetails.log
+	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc 2>&1 | tee trajectDetails.log
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}')
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')
 	simDuratnpsINT=$(echo ${simDuratnps%\.*})
@@ -227,7 +227,7 @@ else
 	{
 		echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 		sleep 2
-		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc |2>&1 | tee trajectDetails.log		
+		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc 2>&1 | tee trajectDetails.log		
 	}
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}') || ScanTraj_again_if_err
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')

--- a/CHAP_modules/CHAP_ana.sh
+++ b/CHAP_modules/CHAP_ana.sh
@@ -210,7 +210,7 @@ fi
 if [[ ! -f "trajectDetails.log" ]]; then
 	echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 	sleep 2
-	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc |& tee trajectDetails.log
+	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc | tee trajectDetails.log
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}')
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')
 	simDuratnpsINT=$(echo ${simDuratnps%\.*})
@@ -227,7 +227,7 @@ else
 	{
 		echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 		sleep 2
-		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc |& tee trajectDetails.log		
+		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc | tee trajectDetails.log		
 	}
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}') || ScanTraj_again_if_err
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')

--- a/CHAP_modules/CHAP_deffxn.sh
+++ b/CHAP_modules/CHAP_deffxn.sh
@@ -2133,7 +2133,7 @@ ScanTRAJ_SMD()
 if [[ ! -f "SMD_trajectDetails.log" ]]; then
 	echo "${demA}"$' Checking the SMD trajectory to extract info about the number of frames and\n simulation time'"${demB}"
 	sleep 2
-	eval $gmx_exe_path check -f pull.xtc | tee SMD_trajectDetails.log
+	eval $gmx_exe_path check -f pull.xtc 2>&1 tee SMD_trajectDetails.log
 	No_of_frames=$(cat SMD_trajectDetails.log | grep "Last" | awk '{print $(NF-2)}')
 	simDuratnps=$(cat SMD_trajectDetails.log | grep "Last" | awk '{print $NF}')
 	sim_timestep=$(cat SMD_trajectDetails.log | grep -A1 "Item" | awk '{print $NF}' | tail -n 1)
@@ -2353,7 +2353,7 @@ fi
 if [[ ! -f "trajectDetails.log" ]]; then
 	echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 	sleep 2
-	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc | tee trajectDetails.log
+	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc 2>&1 tee trajectDetails.log
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}')
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')
 	simDuratnpsINT=$(echo ${simDuratnps%\.*})
@@ -2370,7 +2370,7 @@ else
 	{
 		echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 		sleep 2
-		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc | tee trajectDetails.log		
+		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc 2>&1 tee trajectDetails.log		
 	}
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}') || ScanTraj_again_if_err
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')

--- a/CHAP_modules/CHAP_deffxn.sh
+++ b/CHAP_modules/CHAP_deffxn.sh
@@ -2133,7 +2133,7 @@ ScanTRAJ_SMD()
 if [[ ! -f "SMD_trajectDetails.log" ]]; then
 	echo "${demA}"$' Checking the SMD trajectory to extract info about the number of frames and\n simulation time'"${demB}"
 	sleep 2
-	eval $gmx_exe_path check -f pull.xtc 2>&1 tee SMD_trajectDetails.log
+	eval $gmx_exe_path check -f pull.xtc 2>&1 | tee SMD_trajectDetails.log
 	No_of_frames=$(cat SMD_trajectDetails.log | grep "Last" | awk '{print $(NF-2)}')
 	simDuratnps=$(cat SMD_trajectDetails.log | grep "Last" | awk '{print $NF}')
 	sim_timestep=$(cat SMD_trajectDetails.log | grep -A1 "Item" | awk '{print $NF}' | tail -n 1)
@@ -2353,7 +2353,7 @@ fi
 if [[ ! -f "trajectDetails.log" ]]; then
 	echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 	sleep 2
-	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc 2>&1 tee trajectDetails.log
+	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc 2>&1 | tee trajectDetails.log
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}')
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')
 	simDuratnpsINT=$(echo ${simDuratnps%\.*})
@@ -2370,7 +2370,7 @@ else
 	{
 		echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 		sleep 2
-		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc 2>&1 tee trajectDetails.log		
+		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc 2>&1 | tee trajectDetails.log		
 	}
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}') || ScanTraj_again_if_err
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')

--- a/CHAP_modules/CHAP_deffxn.sh
+++ b/CHAP_modules/CHAP_deffxn.sh
@@ -2133,7 +2133,7 @@ ScanTRAJ_SMD()
 if [[ ! -f "SMD_trajectDetails.log" ]]; then
 	echo "${demA}"$' Checking the SMD trajectory to extract info about the number of frames and\n simulation time'"${demB}"
 	sleep 2
-	eval $gmx_exe_path check -f pull.xtc |& tee SMD_trajectDetails.log
+	eval $gmx_exe_path check -f pull.xtc | tee SMD_trajectDetails.log
 	No_of_frames=$(cat SMD_trajectDetails.log | grep "Last" | awk '{print $(NF-2)}')
 	simDuratnps=$(cat SMD_trajectDetails.log | grep "Last" | awk '{print $NF}')
 	sim_timestep=$(cat SMD_trajectDetails.log | grep -A1 "Item" | awk '{print $NF}' | tail -n 1)
@@ -2353,7 +2353,7 @@ fi
 if [[ ! -f "trajectDetails.log" ]]; then
 	echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 	sleep 2
-	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc |& tee trajectDetails.log
+	eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc | tee trajectDetails.log
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}')
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')
 	simDuratnpsINT=$(echo ${simDuratnps%\.*})
@@ -2370,7 +2370,7 @@ else
 	{
 		echo -e "${demA} Checking the trajectory to extract info about the number of frames and\n simulation time${demB}"
 		sleep 2
-		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc |& tee trajectDetails.log		
+		eval "$gmx_exe_path" check -f "${filenm}"_${wraplabel}.xtc | tee trajectDetails.log		
 	}
 	No_of_frames=$(cat trajectDetails.log | grep "Last" | awk '{print $(NF-2)}') || ScanTraj_again_if_err
 	simDuratnps=$(cat trajectDetails.log | grep "Last" | awk '{print $NF}')

--- a/conda_dependencies.yml
+++ b/conda_dependencies.yml
@@ -17,7 +17,8 @@ dependencies:
 # Although numpy 1.18.5 & 1.23.4 both worked with python 3.8.10, 3.8.13, 3.8.15, 3.8.16
     - matplotlib # tested versions: 3.6.1, 3.6.2, 3.6.3
     # - pycairo
-    - networkx==2.5
+    - networkx==2.3
+    # - networkx==2.5 # if nextworkx==2.3 fails, try networkx==2.5
     - biopandas
     - biopython
     - click

--- a/conda_dependencies.yml
+++ b/conda_dependencies.yml
@@ -17,7 +17,7 @@ dependencies:
 # Although numpy 1.18.5 & 1.23.4 both worked with python 3.8.10, 3.8.13, 3.8.15, 3.8.16
     - matplotlib # tested versions: 3.6.1, 3.6.2, 3.6.3
     # - pycairo
-    - networkx==2.3
+    - networkx==2.5
     - biopandas
     - biopython
     - click


### PR DESCRIPTION
When I ran 
```
run_CHAPERONg.sh
```
The following errors were shown:
```
/Users/pritam/Downloads/CHAPERONg-main/CHAP_modules/CHAP_deffxn.sh: line 2136: syntax error near unexpected token `&'
(base) ➜  Downloads run_CHAPERONg.sh
/Users/pritam/Downloads/CHAPERONg-main/CHAP_modules/CHAP_deffxn.sh: line 2356: syntax error near unexpected token `&'
(base) ➜  Downloads run_CHAPERONg.sh
/Users/pritam/Downloads/CHAPERONg-main/CHAP_modules/CHAP_deffxn.sh: line 2373: syntax error near unexpected token `&'
(base) ➜  Downloads run_CHAPERONg.sh
/Users/pritam/Downloads/CHAPERONg-main/CHAP_modules/CHAP_ana.sh: line 213: syntax error near unexpected token `&'
(base) ➜  Downloads run_CHAPERONg.sh
/Users/pritam/Downloads/CHAPERONg-main/CHAP_modules/CHAP_ana.sh: line 230: syntax error near unexpected token `&'
```

So I have removed "&" from the code and it worked again:

```
run_CHAPERONg.sh
 
############################################################################### 
#--------------------------------- CHAPERONg ---------------------------------# 
#              If you use this program in your work, please cite:             # 
#  Yekeen A.A., Durojaye O.A., Idris M.O., Muritala H.F., Arise R.O. (2023).  # 
#      CHAPERONg: A tool for automated GROMACS-based molecular dynamics       # 
#   simulations  and  trajectory  analyses,  Computational  and  Structural   # 
#                    Biotechnology Journal 21: 4849-4858.                     # 
############################################################################### 

##*********************************CHAPERONg**********************************##

 What type of simulation do you want to run?
  (1)  Conventional MD simulation -- Unbiased/Regular
  (2)  Enhanced (umbrella) sampling simulation -- Biased

 *ENTER YOUR CHOICE HERE (1 or 2): 

```